### PR TITLE
Feature/fix706

### DIFF
--- a/opendrive2lanelet2/convertor/opendrive2lanelet2convertor.py
+++ b/opendrive2lanelet2/convertor/opendrive2lanelet2convertor.py
@@ -59,7 +59,10 @@ class Opendrive2Lanelet2Convertor:
     def write_xml_to_file(self,fn):
         fn = fn.replace(".xodr","")
 
-        self.root.append(xml.Element('geoReference', {'v': self.geoReference}))
+        #self.root.append(xml.Element('geoReference', {'v': self.geoReference}))
+        geo_reference = xml.Element('geoReference')
+        geo_reference.text = self.geoReference
+        self.root.append(geo_reference)
 
         for child in self.nodes.getchildren():
             self.root.append(child)
@@ -154,11 +157,6 @@ class Opendrive2Lanelet2Convertor:
             ratio_matches = 2 * num_matches / np.shape(combined)[0]
 
             if num_matches > intersection_test_tresh:
-                print(f'Passed number test, ratio is {ratio_matches}')
-                plt.plot(test_pts[:,0], test_pts[:,1], 'go-', alpha=0.5, linewidth=4, label='New pts')
-                plt.plot(pts[:,0], pts[:,1], 'r+-',label='Current pts')
-                plt.legend()
-                plt.show()
                 if ratio_matches > intersection_test_tresh_ratio:
                     return k
         return way

--- a/opendrive2lanelet2/convertor/opendrive2lanelet2convertor.py
+++ b/opendrive2lanelet2/convertor/opendrive2lanelet2convertor.py
@@ -22,8 +22,6 @@ from opendrive2lanelet2.elements.way import Way
 from opendrive2lanelet2.elements.relation import Relation
 from opendrive2lanelet2.elements.speed_limit_regulatory import SpeedLimitRegulatory
 
-import matplotlib.pyplot as plt
-
 __author__ = "Samir Tabriz"
 __version__ = "1.0.0"
 __maintainer__ = "Samir Tabriz"
@@ -59,7 +57,6 @@ class Opendrive2Lanelet2Convertor:
     def write_xml_to_file(self,fn):
         fn = fn.replace(".xodr","")
 
-        #self.root.append(xml.Element('geoReference', {'v': self.geoReference}))
         geo_reference = xml.Element('geoReference')
         geo_reference.text = self.geoReference
         self.root.append(geo_reference)
@@ -179,7 +176,7 @@ class Opendrive2Lanelet2Convertor:
             self.all_ways.append(left_way)
 
             print(right_way_id)
-            #right_way = self.check_way_duplication(right_nodes,right_way)
+            right_way = self.check_way_duplication(right_nodes,right_way)
             self.all_ways.append(right_way)
 
             self.ways.append(left_way.create_xml_way_object())

--- a/opendrive2lanelet2/convertor/opendrive2lanelet2convertor.py
+++ b/opendrive2lanelet2/convertor/opendrive2lanelet2convertor.py
@@ -131,31 +131,25 @@ class Opendrive2Lanelet2Convertor:
                 self.nodes.append(node.create_xml_node_object())
                 self.all_nodes.append(node)
         return nodes
-    # calculate area between multiple curves
-    def area_between_curve(self,c1,c2):
 
-        c1_fit = np.polyfit(c1[0],c1[1],3)
-        c2_fit = np.polyfit(c2[0],c2[1],3)
-
-        c1_1d_fun = np.poly1d(c1_fit)
-        c2_1d_fun = np.poly1d(c2_fit)
-        
-        n = np.polyint((c2_1d_fun - c1_1d_fun))
-        return n, c1_1d_fun, c2_1d_fun
     # check for way duplication in the entire map
     def check_way_duplication(self,nodes,way):
+	# For a duplicate, need at least 5, and at least 80% matching points
         intersection_test_tresh = 5
         intersection_test_tresh_ratio = 0.8
 
         for k in self.all_ways:
+	    # Get list of points in existing and candidate ways
             test_pts = np.array([[np.round(j.local_x, 3), np.round(j.local_y, 3)] for j in k.nodes])
             pts = np.array([[np.round(j.local_x, 3), np.round(j.local_y, 3)] for j in nodes])
 
+	    # Count the number and ratio of duplicate points
             combined = np.concatenate((test_pts, pts))
             tmp, indices = np.unique(combined, axis=0, return_index=True)
             num_matches = np.shape(combined)[0] - len(indices)
             ratio_matches = 2 * num_matches / np.shape(combined)[0]
 
+	    # If the ratio and count tests pass, re-use the esisting way
             if num_matches > intersection_test_tresh:
                 if ratio_matches > intersection_test_tresh_ratio:
                     return k

--- a/opendrive2lanelet2/convertor/opendrive2lanelet2convertor.py
+++ b/opendrive2lanelet2/convertor/opendrive2lanelet2convertor.py
@@ -171,11 +171,9 @@ class Opendrive2Lanelet2Convertor:
             right_way_id = relation_id + '1'
             right_way = Way(right_way_id,right_nodes, max_speed)
 
-            print(left_way_id)
             left_way = self.check_way_duplication(left_nodes,left_way)
             self.all_ways.append(left_way)
 
-            print(right_way_id)
             right_way = self.check_way_duplication(right_nodes,right_way)
             self.all_ways.append(right_way)
 


### PR DESCRIPTION
Updated the opewndrive2lanelet2convertor.py file to fix:
1) geoReference tag issue with route unit test
2) de-duplication catching extra lanelet bohundaries, causing https://usdot-carma.atlassian.net/browse/CAR-2671.

For de-duplication, the method was changed. The area constraint was removed, since it fails entirely when an input curve has multiple points at the same x-value (eg. a circle). The point-matching condition was changed because originally the file matches x and y values separately, so two mirrored lines (\ and /) contain the same x values, and the same y values, but not the same (x, y) values. Numpy libraries were used to find the number of duplicate points in each list. After this, the condition was changed from 30 points to 5 points AND 80% of the total number of points. Some boundaries may not have 30 points, yet we don't want the threshold so low that just matching the start or end removes a boundary. 