### PR TITLE
Fix/782

### DIFF
--- a/opendrive2lanelet2/convertor/opendrive2lanelet2convertor.py
+++ b/opendrive2lanelet2/convertor/opendrive2lanelet2convertor.py
@@ -150,6 +150,20 @@ class Opendrive2Lanelet2Convertor:
             node = self.convert_vertice_to_node(node_id, vertices[j])
             node_latlon = np.array([node.lat, node.lon])
 
+            # Ensure that the node's lat and lon are within the maximum bounds
+            if node.lat > 90:
+                print(f'Node {node.id:d} contains an invalid lat value of {node.lat:.12f}. Setting to 90')
+                node.lat = 90
+            elif node.lat < -90:
+                print(f'Node {node.id:d} contains an invalid lat value of {node.lat:.12f}. Setting to -90')
+                node.lat = -90
+            if node.lon > 180:
+                print(f'Node {node.id:d} contains an invalid lon value of {node.lon:.12f}. Setting to 180')
+                node.lon = 180
+            elif node.lon < -180:
+                print(f'Node {node.id:d} contains an invalid lon value of {node.lon:.12f}. Setting to -180')
+                node.lon = -180
+
             is_dup, index = self.check_duplicate_hash_precise(node_latlon)
             if is_dup:
                 nodes.append(self.all_nodes[index])

--- a/opendrive2lanelet2/convertor/opendrive2lanelet2convertor.py
+++ b/opendrive2lanelet2/convertor/opendrive2lanelet2convertor.py
@@ -128,7 +128,7 @@ class Opendrive2Lanelet2Convertor:
                     test_key = self.key_from_latlon_prec(test)
                 except OverflowError:
                     print('Lat or lon over max value')
-                    print('value is: ' + str([new * tolerance]))
+                    print('value is: ' + str(new * tolerance))
                     return False, None
 
                 if test_key in self.all_nodes_dict:
@@ -148,22 +148,22 @@ class Opendrive2Lanelet2Convertor:
         for j in range(len(vertices)):
             node_id = relation_id + str(bound_id) + "{0:0=3d}".format(j)
             node = self.convert_vertice_to_node(node_id, vertices[j])
-            node_latlon = np.array([node.lat, node.lon])
 
             # Ensure that the node's lat and lon are within the maximum bounds
             if node.lat > 90:
-                print(f'Node {node.id:d} contains an invalid lat value of {node.lat:.12f}. Setting to 90')
+                print(f'Node {node.id:s} contains an invalid lat value of {node.lat:.12f}. Setting to 90')
                 node.lat = 90
             elif node.lat < -90:
-                print(f'Node {node.id:d} contains an invalid lat value of {node.lat:.12f}. Setting to -90')
+                print(f'Node {node.id:s} contains an invalid lat value of {node.lat:.12f}. Setting to -90')
                 node.lat = -90
             if node.lon > 180:
-                print(f'Node {node.id:d} contains an invalid lon value of {node.lon:.12f}. Setting to 180')
+                print(f'Node {node.id:s} contains an invalid lon value of {node.lon:.12f}. Setting to 180')
                 node.lon = 180
             elif node.lon < -180:
-                print(f'Node {node.id:d} contains an invalid lon value of {node.lon:.12f}. Setting to -180')
+                print(f'Node {node.id:s} contains an invalid lon value of {node.lon:.12f}. Setting to -180')
                 node.lon = -180
 
+            node_latlon = np.array([node.lat, node.lon])
             is_dup, index = self.check_duplicate_hash_precise(node_latlon)
             if is_dup:
                 nodes.append(self.all_nodes[index])


### PR DESCRIPTION
# PR Details
## Description
Fixed an issue where massive values in the input XODR map result in the latitude and longitude being stores as 'inf', which causes the file to be unopenable in JOSM. 

The improvement is adding if statements to catch values outside the valid range of lat/lon (90 to -90 and 180 to -180) and set them to the limit, as well as printing to the user .

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/782

## Motivation and Context
OSM maps with inf lat/lon values cannot be opened in JOSM. 

## How Has This Been Tested?
This was tested by converting the McLean_loop map, and opening it successfully in JOSM. The file was also put through the routing unit test in carma-platform and passed. 

It's still not a perfect solution, as the fixed nodes show up at the limit lat/lon locations, leading to situations like:
![image](https://user-images.githubusercontent.com/65964406/89064262-e73d6580-d326-11ea-9e15-8510dfcb3576.png)

## Types of changes
 - [x] Defect fix (non-breaking change that fixes an issue)
 - [ ] New feature (non-breaking change that adds functionality)
 - [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:
 - [x] I have added any new packages to the sonar-scanner.properties file
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
 - [x] I have read the CONTRIBUTING document.
 - [ ] I have added tests to cover my changes.
 - [x] All new and existing tests passed.