### PR TITLE
Update to python 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.8
 
 COPY . /root/opendrive2lanelet
 


### PR DESCRIPTION
Currently the docker build fails with the following:
```
...
  File "/usr/local/lib/python3.6/site-packages/setuptools/sandbox.py", line 43, in _execfile
    exec(code, globals, locals)
  File "/tmp/easy_install-i4egu5x8/scipy-1.6.0/setup.py", line 31, in <module>
    extras_require={"GUI": ["PyQt5>=5.12.2", "matplotlib>=3.1.0"]},
RuntimeError: Python version >= 3.7 required.
The command '/bin/sh -c python setup.py install' returned a non-zero code: 1
```

Updating to 3.8 resolves the failure.